### PR TITLE
Update deprecated compiler flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,7 @@ rustflags = [
   #   trap unreachable can save a lot of space, but requires nightly compiler.
   #   uncomment the next line if you wish to enable it
   # "-Z", "trap-unreachable=no",
-  "-C", "inline-threshold=5",
+  "-Cllvm-args=--inline-threshold=5",
   "-C", "no-vectorize-loops",
 ]
 


### PR DESCRIPTION
I was getting the error:
  warning: the `-Cinline-threshold` flag is deprecated and does nothing (consider using `-Cllvm-args=--inline-threshold=...`)
So I did what it said.